### PR TITLE
Check image is not empty before use

### DIFF
--- a/src/libImaging/Geometry.c
+++ b/src/libImaging/Geometry.c
@@ -791,13 +791,13 @@ ImagingGenericTransform(
     char *out;
     double xx, yy;
 
+    if (!imOut || !imIn || strcmp(imIn->mode, imOut->mode) != 0) {
+        return (Imaging)ImagingError_ModeError();
+    }
+
     ImagingTransformFilter filter = getfilter(imIn, filterid);
     if (!filter) {
         return (Imaging)ImagingError_ValueError("bad filter number");
-    }
-
-    if (!imOut || !imIn || strcmp(imIn->mode, imOut->mode) != 0) {
-        return (Imaging)ImagingError_ModeError();
     }
 
     ImagingCopyPalette(imOut, imIn);


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/8398

The same problem that you've fixed also exists at https://github.com/PavlNekrasov/Pillow/blob/0f47ecd4325268156c27fa86799d31829f31fcea/src/libImaging/Geometry.c#L794-L801
https://github.com/PavlNekrasov/Pillow/blob/0f47ecd4325268156c27fa86799d31829f31fcea/src/libImaging/Geometry.c#L709-L712